### PR TITLE
Update package and dependency version to match updated upstream source.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <groupId>com.glyptodon.guacamole</groupId>
     <artifactId>guacamole-auth-restrict</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-3</version>
+    <version>1.1.0-1</version>
     <name>guacamole-auth-restrict</name>
     <url>https://glyptodon.com/</url>
 
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
In the time since this extension was originally developed, the upstream version number has been bumped. The corresponding version number within the `pom.xml` must be updated for the build to succeed.